### PR TITLE
Write test cases to test the Create Command

### DIFF
--- a/docs/team/jinyang628.md
+++ b/docs/team/jinyang628.md
@@ -1,6 +1,6 @@
 ---
-  layout: default.md
-  title: "Chen Jin Yang's Project Portfolio Page"
+layout: default.md
+title: "Chen Jin Yang's Project Portfolio Page"
 ---
 
 ## Project: Flagship
@@ -13,6 +13,7 @@ Flagship is a desktop application used to help aspiring students track internshi
     * Refactored the AB3 models and interfaces so that they can be repurposed for Flagship
         * E.g. Adding new parameters, renaming interfaces, etc.
     * Programmed the Create Command so that users can key in internship details
+    * Wrote test cases to comprehensively test the Create Command 
     * [RepoSense link](https://nus-cs2103-ay2324s1.github.io/tp-dashboard/?search=&sort=groupTitle&sortWithin=title&timeframe=commit&mergegroup=&groupSelect=groupByRepos&breakdown=true&checkedFileTypes=docs~functional-code~test-code&since=2023-09-22&tabOpen=true&tabType=authorship&tabAuthor=jinyang628&tabRepo=AY2324S1-CS2103T-W17-1%2Ftp%5Bmaster%5D&authorshipIsMergeGroup=false&authorshipFileTypes=docs~functional-code~test-code&authorshipIsBinaryFileTypeChecked=false&authorshipIsIgnoredFilesChecked=false)
 
 * **Enhancements to existing features**:
@@ -36,7 +37,9 @@ Flagship is a desktop application used to help aspiring students track internshi
   * (eg. Managed releases `v1.3` - `v1.5rc` (3 releases) on GitHub)
 
 * **Community**:
-  * PRs reviewed: [\#23](https://github.com/AY2324S1-CS2103T-W17-1/tp/pull/23)
+  * PRs reviewed: 
+    [\#23](https://github.com/AY2324S1-CS2103T-W17-1/tp/pull/23), 
+    [\#57](https://github.com/AY2324S1-CS2103T-W17-1/tp/pull/57)
   * Contributed to forum discussions (examples: to be added soon)
   * Reported bugs and suggestions for other teams in the class (examples: to be added soon)
 

--- a/src/test/java/seedu/address/logic/commands/CreateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CreateCommandTest.java
@@ -1,29 +1,25 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-//import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
-//import static seedu.address.testutil.TypicalInternships.JANE_STREET;
+import static seedu.address.testutil.TypicalInternships.JANESTREET;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
-//import java.util.Arrays;
+import java.util.Arrays;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-//import seedu.address.logic.Messages;
-//import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.AddressBook;
-import seedu.address.model.Model;
-import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.*;
 import seedu.address.model.internship.Internship;
-import seedu.address.model.person.Person;
 import seedu.address.testutil.InternshipBuilder;
 
 public class CreateCommandTest {
@@ -32,30 +28,30 @@ public class CreateCommandTest {
         assertThrows(NullPointerException.class, () -> new CreateCommand(null));
     }
 
-    //    @Test
-    //    public void execute_internshipAcceptedByModel_createSuccessful() throws Exception {
-    //        CreateCommandTest.ModelStufAcceptingInternshipCreated modelStub = new CreateCommandTest
-    //                .ModelStufAcceptingInternshipCreated();
-    //        Internship validInternship = new InternshipBuilder().build();
-    //
-    //        CommandResult commandResult = new CreateCommand(validInternship).execute(modelStub);
-    //
-    //        assertEquals(String.format(CreateCommand.MESSAGE_SUCCESS, Messages.format(validInternship)),
-    //                commandResult.getFeedbackToUser());
-    //        assertEquals(Arrays.asList(validInternship), modelStub.internshipsCreated);
-    //    }
-    //
-    //    @Test
-    //    public void execute_duplicateInternship_throwsCommandException() {
-    //        Internship validInternship = new InternshipBuilder().build();
-    //        CreateCommand createCommand = new CreateCommand(validInternship);
-    //        CreateCommandTest.ModelStub modelStub = new CreateCommandTest.ModelStubWithInternship(validInternship);
-    //
-    //        assertThrows(
-    //                CommandException.class,
-    //                CreateCommand.MESSAGE_DUPLICATE_INTERNSHIP, () -> createCommand.execute(modelStub)
-    //        );
-    //    }
+    @Test
+    public void execute_internshipAcceptedByModel_createSuccessful() throws Exception {
+        CreateCommandTest.ModelStubAcceptingInternshipCreated modelStub = new CreateCommandTest
+                .ModelStubAcceptingInternshipCreated();
+        Internship validInternship = new InternshipBuilder().build();
+
+        CommandResult commandResult = new CreateCommand(validInternship).execute(modelStub);
+
+        assertEquals(String.format(CreateCommand.MESSAGE_SUCCESS, Messages.format(validInternship)),
+                commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(validInternship), modelStub.internshipsCreated);
+    }
+
+    @Test
+    public void execute_duplicateInternship_throwsCommandException() {
+        Internship validInternship = new InternshipBuilder().build();
+        CreateCommand createCommand = new CreateCommand(validInternship);
+        CreateCommandTest.ModelStub modelStub = new CreateCommandTest.ModelStubWithInternship(validInternship);
+
+        assertThrows(
+                CommandException.class,
+                CreateCommand.MESSAGE_DUPLICATE_INTERNSHIP, () -> createCommand.execute(modelStub)
+        );
+    }
 
     @Test
     public void equals() {
@@ -81,24 +77,25 @@ public class CreateCommandTest {
         assertFalse(addJaneStreetCommand.equals(addGoogleCommand));
     }
 
-    //    @Test
-    //    public void toStringMethod() {
-    //        AddCommand addCommand = new AddCommand(ALICE);
-    //        String expected = AddCommand.class.getCanonicalName() + "{toAdd=" + ALICE + "}";
-    //        assertEquals(expected, addCommand.toString());
-    //    }
+    @Test
+    public void toStringMethod() {
+        CreateCommand createCommand = new CreateCommand(JANESTREET);
+        String expected = CreateCommand.class.getCanonicalName() + "{toAdd=" + JANESTREET + "}";
+        assertEquals(expected, createCommand.toString());
+    }
 
     /**
      * A default model stub that have all of the methods failing.
      */
-    private class ModelStub implements Model {
+    private class ModelStub implements InternshipModel {
+
         @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        public void setUserPrefs(ReadOnlyInternshipUserPrefs userPrefs) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
+        public ReadOnlyInternshipUserPrefs getUserPrefs() {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -113,12 +110,12 @@ public class CreateCommandTest {
         }
 
         @Override
-        public Path getAddressBookFilePath() {
+        public Path getInternshipBookFilePath() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void setAddressBookFilePath(Path addressBookFilePath) {
+        public void setInternshipBookFilePath(Path internshipBookFilePath) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -128,12 +125,12 @@ public class CreateCommandTest {
         }
 
         @Override
-        public void setAddressBook(ReadOnlyAddressBook newData) {
+        public void setInternshipBook(ReadOnlyInternshipBook newData) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public ReadOnlyAddressBook getAddressBook() {
+        public ReadOnlyInternshipBook getInternshipBook() {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -161,37 +158,8 @@ public class CreateCommandTest {
         public void updateFilteredInternshipList(Predicate<Internship> predicate) {
             throw new AssertionError("This method should not be called.");
         }
-
-        @Override
-        public void deletePerson(Person target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Person> getFilteredPersonList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setPerson(Person target, Person editedPerson) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
     }
+
     /**
      * A Model stub that contains a single internship.
      */
@@ -213,7 +181,7 @@ public class CreateCommandTest {
     /**
      * A Model stub that always accept the internship being added.
      */
-    private class ModelStufAcceptingInternshipCreated extends ModelStub {
+    private class ModelStubAcceptingInternshipCreated extends ModelStub {
         final ArrayList<Internship> internshipsCreated = new ArrayList<>();
 
         @Override
@@ -229,8 +197,8 @@ public class CreateCommandTest {
         }
 
         @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            return new AddressBook();
+        public ReadOnlyInternshipBook getInternshipBook() {
+            return new InternshipBook();
         }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CreateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CreateCommandTest.java
@@ -18,7 +18,10 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.*;
+import seedu.address.model.InternshipBook;
+import seedu.address.model.InternshipModel;
+import seedu.address.model.ReadOnlyInternshipBook;
+import seedu.address.model.ReadOnlyInternshipUserPrefs;
 import seedu.address.model.internship.Internship;
 import seedu.address.testutil.InternshipBuilder;
 


### PR DESCRIPTION
Currently, the test cases do not cover most of the functionalities of the Create Command.

Test cases are important so that with every new iteration, we can be sure that our old implementations are still working.

Write more test cases to fully test the Create Command.

Fixes #62 
