### PR TITLE
Fix create command bugs in PE

### DIFF
--- a/src/main/java/seedu/address/Main.java
+++ b/src/main/java/seedu/address/Main.java
@@ -5,8 +5,6 @@ import java.util.logging.Logger;
 import javafx.application.Application;
 import seedu.address.commons.core.LogsCenter;
 
-// THIS FILE WILL BE REMOVED EVENTUALLY
-
 /**
  * The main entry point to the application.
  *

--- a/src/main/java/seedu/address/model/internship/CompanyName.java
+++ b/src/main/java/seedu/address/model/internship/CompanyName.java
@@ -9,8 +9,10 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class CompanyName implements Comparable<CompanyName> {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Company names should only contain alphanumeric characters and spaces, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "The company name should fulfill all the following conditions:\n"
+            + "1. Contains only english alphanumeric characters and spaces\n"
+            + "2. Should not be blank\n"
+            + "3. Cannot be longer than 200 characters";
 
     public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
@@ -28,12 +30,16 @@ public class CompanyName implements Comparable<CompanyName> {
     }
 
     /**
-     * Verifies whether the given string constitutes a valid company name.
+     * Verifies whether the given string constitutes a valid company name. Company names longer than 200 characters
+     * are rejected to prevent overflows in the UI.
      *
      * @param test The given string to be tested.
      * @return A boolean representing whether the string input is valid.
      */
     public static boolean isValidCompanyName(String test) {
+        if (test.length() > 200) {
+            return false;
+        }
         return test.matches(VALIDATION_REGEX);
     }
 

--- a/src/main/java/seedu/address/model/internship/Role.java
+++ b/src/main/java/seedu/address/model/internship/Role.java
@@ -9,8 +9,10 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Role implements Comparable<Role> {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Role should only contain alphanumeric characters and spaces, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "The role should fulfill all the following conditions:\n"
+            + "1. Contains only english alphanumeric characters and spaces\n"
+            + "2. Should not be blank\n"
+            + "3. Cannot be longer than 200 characters";
 
     public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
@@ -28,12 +30,16 @@ public class Role implements Comparable<Role> {
     }
 
     /**
-     * Verifies whether the given string constitutes a valid role.
+     * Verifies whether the given string constitutes a valid role. Roles longer than 200 characters are rejected to
+     * prevent overflows in the UI.
      *
      * @param test The given string to be tested.
      * @return A boolean representing whether the string input is valid.
      */
     public static boolean isValidRole(String test) {
+        if (test.length() > 200) {
+            return false;
+        }
         return test.matches(VALIDATION_REGEX);
     }
 

--- a/src/main/java/seedu/address/model/requirement/Requirement.java
+++ b/src/main/java/seedu/address/model/requirement/Requirement.java
@@ -9,8 +9,12 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Requirement {
 
-    public static final String MESSAGE_CONSTRAINTS = "Requirements cannot be empty";
-    public static final String VALIDATION_REGEX = ".+\\S.+";
+    public static final String MESSAGE_CONSTRAINTS = "Each requirement should fulfill all the following conditions:\n"
+            + "1. Should not be blank\n"
+            + "2. Should not contain foreign langauge characters\n"
+            + "3. Cannot be longer than 200 characters";
+
+    public static final String VALIDATION_REGEX = "[ -~]+";
 
     private final String requirementName;
 
@@ -26,12 +30,16 @@ public class Requirement {
     }
 
     /**
-     * Verifies whether the given string constitutes a valid requirement.
+     * Verifies whether the given string constitutes a valid requirement. Requirements longer than 200 characters are
+     * rejected to prevent overflows in the UI.
      *
      * @param test The given string to be tested.
      * @return A boolean representing whether the string input is valid.
      */
     public static boolean isValidRequirementName(String test) {
+        if (test.length() > 200) {
+            return false;
+        }
         return test.matches(VALIDATION_REGEX);
     }
 

--- a/src/test/java/seedu/address/model/internship/CompanyNameTest.java
+++ b/src/test/java/seedu/address/model/internship/CompanyNameTest.java
@@ -30,6 +30,9 @@ class CompanyNameTest {
         assertFalse(CompanyName.isValidCompanyName(" ")); // spaces only
         assertFalse(CompanyName.isValidCompanyName("^")); // only non-alphanumeric characters
         assertFalse(CompanyName.isValidCompanyName("dbs*")); // contains non-alphanumeric characters
+        assertFalse(CompanyName.isValidCompanyName("123456789012345678901234567890123456789012345678901234567" +
+                "89012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345" +
+                "678901234567890123456789012345678901234567890a")); // 201 characters
 
         // valid companyName -> returns true
         assertTrue(CompanyName.isValidCompanyName("takashimaya")); // alphabets only
@@ -37,6 +40,9 @@ class CompanyNameTest {
         assertTrue(CompanyName.isValidCompanyName("123 shopping centre")); // alphanumeric characters
         assertTrue(CompanyName.isValidCompanyName("Capital Trading Centre")); // with capital letters
         assertTrue(CompanyName.isValidCompanyName("DBS Bank 2nd branch")); // long companyNames
+        assertTrue(CompanyName.isValidCompanyName("123456789012345678901234567890123456789012345678901234567" +
+                "89012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345" +
+                "678901234567890123456789012345678901234567890")); // 200 characters
     }
 
     @Test

--- a/src/test/java/seedu/address/model/internship/CompanyNameTest.java
+++ b/src/test/java/seedu/address/model/internship/CompanyNameTest.java
@@ -30,9 +30,9 @@ class CompanyNameTest {
         assertFalse(CompanyName.isValidCompanyName(" ")); // spaces only
         assertFalse(CompanyName.isValidCompanyName("^")); // only non-alphanumeric characters
         assertFalse(CompanyName.isValidCompanyName("dbs*")); // contains non-alphanumeric characters
-        assertFalse(CompanyName.isValidCompanyName("123456789012345678901234567890123456789012345678901234567" +
-                "89012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345" +
-                "678901234567890123456789012345678901234567890a")); // 201 characters
+        assertFalse(CompanyName.isValidCompanyName("123456789012345678901234567890123456789012345678901234567"
+                + "89012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345"
+                + "678901234567890123456789012345678901234567890a")); // 201 characters
 
         // valid companyName -> returns true
         assertTrue(CompanyName.isValidCompanyName("takashimaya")); // alphabets only
@@ -40,9 +40,9 @@ class CompanyNameTest {
         assertTrue(CompanyName.isValidCompanyName("123 shopping centre")); // alphanumeric characters
         assertTrue(CompanyName.isValidCompanyName("Capital Trading Centre")); // with capital letters
         assertTrue(CompanyName.isValidCompanyName("DBS Bank 2nd branch")); // long companyNames
-        assertTrue(CompanyName.isValidCompanyName("123456789012345678901234567890123456789012345678901234567" +
-                "89012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345" +
-                "678901234567890123456789012345678901234567890")); // 200 characters
+        assertTrue(CompanyName.isValidCompanyName("123456789012345678901234567890123456789012345678901234567"
+                + "89012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345"
+                + "678901234567890123456789012345678901234567890")); // 200 characters
     }
 
     @Test

--- a/src/test/java/seedu/address/model/internship/RoleTest.java
+++ b/src/test/java/seedu/address/model/internship/RoleTest.java
@@ -30,6 +30,9 @@ class RoleTest {
         assertFalse(Role.isValidRole(" ")); // spaces only
         assertFalse(Role.isValidRole("^")); // only non-alphanumeric characters
         assertFalse(Role.isValidRole("engineer*")); // contains non-alphanumeric characters
+        assertFalse(Role.isValidRole("123456789012345678901234567890123456789012345678901234567" +
+                "89012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345" +
+                "678901234567890123456789012345678901234567890a")); // 201 characters
 
         // valid role -> returns true
         assertTrue(Role.isValidRole("data analyst")); // alphabets only
@@ -37,6 +40,9 @@ class RoleTest {
         assertTrue(Role.isValidRole("2nd assistant")); // alphanumeric characters
         assertTrue(Role.isValidRole("Data Scientist")); // with capital letters
         assertTrue(Role.isValidRole("Data Scientist and Machine Learning Engineer")); // long roles
+        assertTrue(Role.isValidRole("123456789012345678901234567890123456789012345678901234567" +
+                "89012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345" +
+                "678901234567890123456789012345678901234567890")); // 200 characters
     }
 
     @Test

--- a/src/test/java/seedu/address/model/internship/RoleTest.java
+++ b/src/test/java/seedu/address/model/internship/RoleTest.java
@@ -30,9 +30,9 @@ class RoleTest {
         assertFalse(Role.isValidRole(" ")); // spaces only
         assertFalse(Role.isValidRole("^")); // only non-alphanumeric characters
         assertFalse(Role.isValidRole("engineer*")); // contains non-alphanumeric characters
-        assertFalse(Role.isValidRole("123456789012345678901234567890123456789012345678901234567" +
-                "89012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345" +
-                "678901234567890123456789012345678901234567890a")); // 201 characters
+        assertFalse(Role.isValidRole("123456789012345678901234567890123456789012345678901234567"
+                + "89012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345"
+                + "678901234567890123456789012345678901234567890a")); // 201 characters
 
         // valid role -> returns true
         assertTrue(Role.isValidRole("data analyst")); // alphabets only
@@ -40,9 +40,9 @@ class RoleTest {
         assertTrue(Role.isValidRole("2nd assistant")); // alphanumeric characters
         assertTrue(Role.isValidRole("Data Scientist")); // with capital letters
         assertTrue(Role.isValidRole("Data Scientist and Machine Learning Engineer")); // long roles
-        assertTrue(Role.isValidRole("123456789012345678901234567890123456789012345678901234567" +
-                "89012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345" +
-                "678901234567890123456789012345678901234567890")); // 200 characters
+        assertTrue(Role.isValidRole("123456789012345678901234567890123456789012345678901234567"
+                + "89012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345"
+                + "678901234567890123456789012345678901234567890")); // 200 characters
     }
 
     @Test

--- a/src/test/java/seedu/address/model/requirement/RequirementTest.java
+++ b/src/test/java/seedu/address/model/requirement/RequirementTest.java
@@ -1,13 +1,13 @@
 package seedu.address.model.requirement;
 
-import seedu.address.model.internship.Role;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+
+import seedu.address.model.internship.Role;
 
 public class RequirementTest {
 
@@ -27,9 +27,9 @@ public class RequirementTest {
     public void isValidRequirement() {
         // invalid requirement -> returns false
         assertFalse(Requirement.isValidRequirementName("")); // Empty string
-        assertFalse(Requirement.isValidRequirementName("12345678901234567890123456789012345678901234567890123456" +
-                "890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456" +
-                "678901234567890123456789012345678901234567890a")); // 201 characters
+        assertFalse(Requirement.isValidRequirementName("12345678901234567890123456789012345678901234567890123456"
+                + "890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456"
+                + "678901234567890123456789012345678901234567890a")); // 201 characters
 
         // valid requirement -> returns true
         assertTrue(Requirement.isValidRequirementName("Maths Requirement")); // Alphabets
@@ -37,9 +37,9 @@ public class RequirementTest {
         assertTrue(Requirement.isValidRequirementName("c")); // Single character
         assertTrue(Requirement.isValidRequirementName("B++")); // Alphabets and special symbols
         assertTrue(Requirement.isValidRequirementName("!&^*%)_#^)_#^_+Q")); // Various special symbols
-        assertTrue(Role.isValidRole("123456789012345678901234567890123456789012345678901234567" +
-                "89012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345" +
-                "678901234567890123456789012345678901234567890")); // 200 characters
+        assertTrue(Role.isValidRole("123456789012345678901234567890123456789012345678901234567"
+                + "89012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345"
+                + "678901234567890123456789012345678901234567890")); // 200 characters
     }
 
     @Test

--- a/src/test/java/seedu/address/model/requirement/RequirementTest.java
+++ b/src/test/java/seedu/address/model/requirement/RequirementTest.java
@@ -24,11 +24,14 @@ public class RequirementTest {
     @Test
     public void isValidRequirement() {
         // invalid requirement -> returns false
-        assertFalse(Requirement.isValidRequirementName("   ")); // Only spaces
         assertFalse(Requirement.isValidRequirementName("")); // Empty string
 
         // valid requirement -> returns true
-        assertTrue(Requirement.isValidRequirementName("Maths Requirement"));
+        assertTrue(Requirement.isValidRequirementName("Maths Requirement")); // Alphabets
+        assertTrue(Requirement.isValidRequirementName("C3")); // Alphanumeric
+        assertTrue(Requirement.isValidRequirementName("c")); // Single character
+        assertTrue(Requirement.isValidRequirementName("B++")); // Alphabets and special symbols
+        assertTrue(Requirement.isValidRequirementName("!&^*%)_#^)_#^_+Q")); // Various special symbols
     }
 
     @Test

--- a/src/test/java/seedu/address/model/requirement/RequirementTest.java
+++ b/src/test/java/seedu/address/model/requirement/RequirementTest.java
@@ -1,5 +1,7 @@
 package seedu.address.model.requirement;
 
+import seedu.address.model.internship.Role;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -25,6 +27,9 @@ public class RequirementTest {
     public void isValidRequirement() {
         // invalid requirement -> returns false
         assertFalse(Requirement.isValidRequirementName("")); // Empty string
+        assertFalse(Requirement.isValidRequirementName("12345678901234567890123456789012345678901234567890123456" +
+                "890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456" +
+                "678901234567890123456789012345678901234567890a")); // 201 characters
 
         // valid requirement -> returns true
         assertTrue(Requirement.isValidRequirementName("Maths Requirement")); // Alphabets
@@ -32,6 +37,9 @@ public class RequirementTest {
         assertTrue(Requirement.isValidRequirementName("c")); // Single character
         assertTrue(Requirement.isValidRequirementName("B++")); // Alphabets and special symbols
         assertTrue(Requirement.isValidRequirementName("!&^*%)_#^)_#^_+Q")); // Various special symbols
+        assertTrue(Role.isValidRole("123456789012345678901234567890123456789012345678901234567" +
+                "89012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345" +
+                "678901234567890123456789012345678901234567890")); // 200 characters
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedInternshipTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedInternshipTest.java
@@ -32,7 +32,7 @@ public class JsonAdaptedInternshipTest {
     private static final String INVALID_DURATION = " ";
     private static final String INVALID_ROLE = "C0ff33 M@k&r";
     private static final String INVALID_START_DATE = "50/50/-1111";
-    private static final String INVALID_REQUIREMENT = " ";
+    private static final String INVALID_REQUIREMENT = "哈哈";
 
     private static final String VALID_COMPANY_NAME = JANESTREET.getCompanyName().toString();
     private static final String VALID_APPLICATION_STATUS = JANESTREET.getApplicationStatus().toString();


### PR DESCRIPTION
Currently, there are a few bugs present in the create command.

- Long company name, role and requirement results in overflow in UI
- Requirements prohibit chinese characters but not accurately reflected in error message
- Requirements do not work if there are fewer than 3 characters

These bugs need to be rectified because it affects the user experience.

Rewrite the logic and impose character limits to fix the abovementioned bugs.

Fixes #173 , Fixes #163 , Fixes #136 
