### PR TITLE
Fix filter bug when create new entry

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -42,8 +42,8 @@ public class FilterCommandParser implements InternshipParser<FilterCommand> {
     public static final String MESSAGE_ONE_PARAMETER = "filter command should accept only one parameter at a time.";
     public static final String MESSAGE_STARTDATE_RANGE_FORMAT = "date range should be in the format "
             + "DD/MM/YYYY-DD/MM/YYYY";
-    public static final String MESSAGE_DURATION_RANGE_FORMAT = "duration range should be in the format X-Y";
-    public static final String MESSAGE_DEADLINE_RANGE_FORMAT = "deadline range should be in the format X-Y";
+    public static final String MESSAGE_DURATION_RANGE_FORMAT = "duration range should be in the format START-END";
+    public static final String MESSAGE_DEADLINE_RANGE_FORMAT = "deadline range should be in the format START-END";
     public static final String MESSAGE_NON_EMPTY = "filter command's parameter cannot be empty.";
 
     /*

--- a/src/main/java/seedu/address/model/InternshipModel.java
+++ b/src/main/java/seedu/address/model/InternshipModel.java
@@ -124,6 +124,8 @@ public interface InternshipModel {
      */
     void updateFilteredInternshipList(Predicate<Internship> predicate);
 
+    void updatePredicate(Predicate<Internship> predicate);
+
     void setFilterParameter(String filterParameter);
 
     void setFilterValue(String filterValue);

--- a/src/main/java/seedu/address/model/InternshipModelManager.java
+++ b/src/main/java/seedu/address/model/InternshipModelManager.java
@@ -28,6 +28,7 @@ public class InternshipModelManager implements InternshipModel {
     private Comparator<Internship> currentComparator = InternshipComparators.BY_COMPANY_NAME; // default comparator
     private String currentComparatorPrefix = "c/"; // default comparator prefix
     private SortCommand.Order currentComparatorOrder = SortCommand.Order.ASC; // default comparator order
+    private Predicate<Internship> currentPredicate = PREDICATE_SHOW_ALL_INTERNSHIPS; //default predicate
     private String currentFilterParameter = "default"; // default filter parameter
     private String currentFilterValue = "default"; // default filter value
     private final InternshipBook internshipBook;
@@ -115,7 +116,7 @@ public class InternshipModelManager implements InternshipModel {
     @Override
     public void createInternship(Internship internship) {
         internshipBook.createInternship(internship);
-        updateFilteredInternshipList(PREDICATE_SHOW_ALL_INTERNSHIPS);
+        updateFilteredInternshipList(currentPredicate);
         sortInternships(currentComparator);
     }
 
@@ -192,6 +193,7 @@ public class InternshipModelManager implements InternshipModel {
     @Override
     public void updateFilteredInternshipList(Predicate<Internship> predicate) {
         requireNonNull(predicate);
+        updatePredicate(predicate);
         this.filteredInternships.setPredicate(predicate);
     }
 
@@ -212,4 +214,8 @@ public class InternshipModelManager implements InternshipModel {
                 && filteredInternships.equals(otherModelManager.filteredInternships);
     }
 
+    @Override
+    public void updatePredicate(Predicate<Internship> predicate) {
+        this.currentPredicate = predicate;
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/CreateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CreateCommandTest.java
@@ -204,6 +204,11 @@ public class CreateCommandTest {
         }
 
         @Override
+        public void updatePredicate(Predicate<Internship> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void sortInternships(Comparator<Internship> comparator) {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
Currently, the internship list is not filtered properly when a new entry is created.

The internship list should be filtered properly to correspond to the filter status as displayed by the GUI to avoid confusion.

Let's make sure that the internship list is correctly filtered when a new entry is created with the create command.

fixes #121 