### PR TITLE
Modify deadline

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -39,7 +39,7 @@ public class Messages {
         builder.append(internship.getCompanyName())
                 .append("; Role: ")
                 .append(internship.getRole())
-                .append("; ApplicationStatus: ")
+                .append("; Application Status: ")
                 .append(internship.getApplicationStatus())
                 .append("; Deadline: ")
                 .append(internship.getDeadline())

--- a/src/main/java/seedu/address/logic/commands/ModifyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModifyCommand.java
@@ -2,12 +2,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_APPLICATION_STATUS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DURATION;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_REQUIREMENT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATE;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -54,6 +49,7 @@ public class ModifyCommand extends InternshipCommand {
             + PREFIX_APPLICATION_STATUS + "Yet to apply "
             + PREFIX_START_DATE + "20/01/2023 "
             + PREFIX_DURATION + "3 "
+            + PREFIX_DEADLINE + "25/12/2022 "
             + PREFIX_REQUIREMENT + "C++ "
             + PREFIX_REQUIREMENT + "Python";
 
@@ -94,6 +90,13 @@ public class ModifyCommand extends InternshipCommand {
 
         if (!internshipToEdit.isSameInternship(editedInternship) && model.hasInternship(editedInternship)) {
             throw new CommandException(MESSAGE_DUPLICATE_INTERNSHIP);
+        }
+
+        if (editedInternship.getStartDate() == null && editedInternship.getDeadline() != null) {
+//            if (internshipToEdit.getStartDate().compareTo(editedInternship.getDeadline()) {
+//
+//            }
+            // check if startdate > deadline
         }
 
         model.setInternship(internshipToEdit, editedInternship);
@@ -173,7 +176,8 @@ public class ModifyCommand extends InternshipCommand {
         }
 
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(companyName, role, applicationStatus, startDate, duration, requirements);
+            return CollectionUtil.isAnyNonNull(companyName, role, applicationStatus, startDate,
+                    duration, requirements, deadline);
         }
 
         public Optional<CompanyName> getCompanyName() {

--- a/src/main/java/seedu/address/logic/commands/ModifyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModifyCommand.java
@@ -62,7 +62,7 @@ public class ModifyCommand extends InternshipCommand {
     public static final String MESSAGE_EDIT_INTERNSHIP_SUCCESS = "Edited Internship: %s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_INTERNSHIP =
-            "This internship application already exists in the tracker.";
+            "This internship entry with the corresponding company name and role already exists in the application.";
 
     private final Index index;
     private final EditInternshipDescriptor editInternshipDescriptor;

--- a/src/main/java/seedu/address/logic/commands/ModifyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModifyCommand.java
@@ -2,7 +2,13 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPLICATION_STATUS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DURATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REQUIREMENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATE;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -93,9 +99,9 @@ public class ModifyCommand extends InternshipCommand {
         }
 
         if (editedInternship.getStartDate() == null && editedInternship.getDeadline() != null) {
-//            if (internshipToEdit.getStartDate().compareTo(editedInternship.getDeadline()) {
-//
-//            }
+            //            if (internshipToEdit.getStartDate().compareTo(editedInternship.getDeadline()) {
+            //
+            //            }
             // check if startdate > deadline
         }
 

--- a/src/main/java/seedu/address/logic/commands/ModifyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModifyCommand.java
@@ -67,7 +67,7 @@ public class ModifyCommand extends InternshipCommand {
             "This internship entry with the corresponding company name and role already exists in the application.";
     public static final String MESSAGE_DEADLINE_CONSTRAINTS =
             "Deadline should only contain numbers and slashes. It must follow the form DD/MM/YYYY. It must be earlier"
-                    + " than the Internship's start date.";
+                    + " than the internship entry's start date.";
     private final Index index;
     private final EditInternshipDescriptor editInternshipDescriptor;
 

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -106,4 +106,14 @@ public class ArgumentMultimap {
                 .count();
         return count == 1;
     }
+
+    /**
+     * Returns true if no prefix is present.
+     */
+    public boolean noPrefixPresent() {
+        long count = argMultimap.keySet().stream()
+                .filter(prefix -> !prefix.getPrefix().isEmpty())
+                .count();
+        return count == 0;
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -110,7 +110,7 @@ public class ArgumentMultimap {
     /**
      * Returns true if no prefix is present.
      */
-    public boolean noPrefixPresent() {
+    public boolean isNoPrefixPresent() {
         long count = argMultimap.keySet().stream()
                 .filter(prefix -> !prefix.getPrefix().isEmpty())
                 .count();

--- a/src/main/java/seedu/address/logic/parser/ModifyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ModifyCommandParser.java
@@ -61,17 +61,9 @@ public class ModifyCommandParser implements InternshipParser<ModifyCommand> {
             editInternshipDescriptor.setApplicationStatus(ParserUtil
                     .parseApplicationStatus(argMultimap.getValue(PREFIX_APPLICATION_STATUS).get()));
         }
-        if (argMultimap.getValue(PREFIX_DEADLINE).isPresent() && argMultimap.getValue(PREFIX_START_DATE).isPresent()) {
-            editInternshipDescriptor.setDeadline(
-                    ParserUtil.parseDeadline(
-                            argMultimap.getValue(PREFIX_DEADLINE).get(),
-                            argMultimap.getValue(PREFIX_START_DATE).get()
-                    )
-            );
-        } else {
-            editInternshipDescriptor.setDeadline(
-                    ParserUtil.parseDeadline(argMultimap.getValue(PREFIX_DEADLINE).get())
-            );
+        if (argMultimap.getValue(PREFIX_DEADLINE).isPresent()) {
+            editInternshipDescriptor.setDeadline(ParserUtil
+                    .parseDeadline(argMultimap.getValue(PREFIX_DEADLINE).get()));
         }
         if (argMultimap.getValue(PREFIX_START_DATE).isPresent()) {
             editInternshipDescriptor.setStartDate(ParserUtil

--- a/src/main/java/seedu/address/logic/parser/ModifyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ModifyCommandParser.java
@@ -31,12 +31,12 @@ public class ModifyCommandParser implements InternshipParser<ModifyCommand> {
 
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_COMPANY_NAME, PREFIX_ROLE, PREFIX_APPLICATION_STATUS,
-                        PREFIX_START_DATE, PREFIX_DURATION, PREFIX_REQUIREMENT);
+                        PREFIX_START_DATE, PREFIX_DURATION, PREFIX_REQUIREMENT, PREFIX_DEADLINE);
 
         Index index;
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_COMPANY_NAME, PREFIX_ROLE, PREFIX_APPLICATION_STATUS,
-                PREFIX_START_DATE, PREFIX_DURATION);
+                PREFIX_START_DATE, PREFIX_DURATION, PREFIX_DEADLINE);
 
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
@@ -57,12 +57,17 @@ public class ModifyCommandParser implements InternshipParser<ModifyCommand> {
             editInternshipDescriptor.setApplicationStatus(ParserUtil
                     .parseApplicationStatus(argMultimap.getValue(PREFIX_APPLICATION_STATUS).get()));
         }
-        if (argMultimap.getValue(PREFIX_DEADLINE).isPresent()) {
-            editInternshipDescriptor.setDeadline(ParserUtil
-                    .parseDeadline(
+        if (argMultimap.getValue(PREFIX_DEADLINE).isPresent() && argMultimap.getValue(PREFIX_START_DATE).isPresent()) {
+            editInternshipDescriptor.setDeadline(
+                    ParserUtil.parseDeadline(
                             argMultimap.getValue(PREFIX_DEADLINE).get(),
                             argMultimap.getValue(PREFIX_START_DATE).get()
-                    ));
+                    )
+            );
+        } else {
+            editInternshipDescriptor.setDeadline(
+                    ParserUtil.parseDeadline(argMultimap.getValue(PREFIX_DEADLINE).get())
+            );
         }
         if (argMultimap.getValue(PREFIX_START_DATE).isPresent()) {
             editInternshipDescriptor.setStartDate(ParserUtil

--- a/src/main/java/seedu/address/logic/parser/ModifyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ModifyCommandParser.java
@@ -44,7 +44,7 @@ public class ModifyCommandParser implements InternshipParser<ModifyCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModifyCommand.MESSAGE_USAGE), pe);
         }
 
-        if (argMultimap.noPrefixPresent()) {
+        if (argMultimap.isNoPrefixPresent()) {
             throw new ParseException(ModifyCommand.MESSAGE_NOT_EDITED);
         }
 

--- a/src/main/java/seedu/address/logic/parser/ModifyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ModifyCommandParser.java
@@ -44,6 +44,10 @@ public class ModifyCommandParser implements InternshipParser<ModifyCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModifyCommand.MESSAGE_USAGE), pe);
         }
 
+        if (argMultimap.noPrefixPresent()) {
+            throw new ParseException(ModifyCommand.MESSAGE_NOT_EDITED);
+        }
+
         EditInternshipDescriptor editInternshipDescriptor = new EditInternshipDescriptor();
 
         if (argMultimap.getValue(PREFIX_COMPANY_NAME).isPresent()) {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -114,9 +114,15 @@ public class ParserUtil {
     public static Deadline parseDeadline(String deadline) throws ParseException {
         requireNonNull(deadline);
         String trimmedDeadline = deadline.trim();
-
-        return new Deadline(trimmedDeadline, "31/12/"
-                + trimmedDeadline.substring(trimmedDeadline.length() - 4));
+        if (!Deadline.isValidDate(trimmedDeadline)) {
+            throw new ParseException(Deadline.MESSAGE_CONSTRAINTS);
+        }
+        String year = trimmedDeadline.substring(trimmedDeadline.length() - 4);
+        String placeHolderStartDate = "31/12/" + year;
+        if (!Deadline.isValidDeadline(trimmedDeadline, placeHolderStartDate)) {
+            throw new ParseException(Deadline.MESSAGE_CONSTRAINTS);
+        }
+        return new Deadline(trimmedDeadline, placeHolderStartDate);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,8 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -117,8 +119,9 @@ public class ParserUtil {
         if (!Deadline.isValidDate(trimmedDeadline)) {
             throw new ParseException(Deadline.MESSAGE_CONSTRAINTS);
         }
-        String year = trimmedDeadline.substring(trimmedDeadline.length() - 4);
-        String placeHolderStartDate = "31/12/" + year;
+        LocalDate maxDate = LocalDate.MAX;
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+        String placeHolderStartDate = maxDate.format(formatter);
         if (!Deadline.isValidDeadline(trimmedDeadline, placeHolderStartDate)) {
             throw new ParseException(Deadline.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -115,8 +115,8 @@ public class ParserUtil {
         requireNonNull(deadline);
         String trimmedDeadline = deadline.trim();
 
-        return new Deadline(trimmedDeadline, "31/12/" +
-                trimmedDeadline.substring(trimmedDeadline.length() - 4));
+        return new Deadline(trimmedDeadline, "31/12/"
+                + trimmedDeadline.substring(trimmedDeadline.length() - 4));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -105,6 +105,21 @@ public class ParserUtil {
     }
 
     /**
+     * Parses a {@code String deadline} into an {@code Deadline}.
+     * This is only for modify command, since user might not include startDate in the command
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code deadline} is invalid.
+     */
+    public static Deadline parseDeadline(String deadline) throws ParseException {
+        requireNonNull(deadline);
+        String trimmedDeadline = deadline.trim();
+
+        return new Deadline(trimmedDeadline, "31/12/" +
+                trimmedDeadline.substring(trimmedDeadline.length() - 4));
+    }
+
+    /**
      * Parses a {@code String startDate} into a {@code StartDate}.
      * Leading and trailing whitespaces will be trimmed.
      *

--- a/src/main/java/seedu/address/model/internship/Deadline.java
+++ b/src/main/java/seedu/address/model/internship/Deadline.java
@@ -52,6 +52,11 @@ public class Deadline implements Comparable<Deadline> {
         }
     }
 
+    /**
+     * Returns true if the given strings for test are valid date.
+     *
+     * @param test The date string to be tested.
+     */
     public static boolean isValidDate(String test) {
         try {
             LocalDate.parse(test, DATE_FORMATTER);

--- a/src/main/java/seedu/address/model/internship/Deadline.java
+++ b/src/main/java/seedu/address/model/internship/Deadline.java
@@ -52,6 +52,15 @@ public class Deadline implements Comparable<Deadline> {
         }
     }
 
+    public static boolean isValidDate(String test) {
+        try {
+            LocalDate.parse(test, DATE_FORMATTER);
+            return true;
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+    }
+
     @Override
     public String toString() {
         return this.deadline.format(DATE_FORMATTER);

--- a/src/test/java/seedu/address/logic/commands/ModifyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ModifyCommandTest.java
@@ -101,29 +101,6 @@ public class ModifyCommandTest {
         assertInternshipCommandSuccess(modifyCommand, model, expectedMessage, expectedModel);
     }
 
-    //    @Test
-    //    public void execute_filteredList_success() {
-    //        showInternshipAtIndex(model, INDEX_FIRST_INTERNSHIP);
-    //
-    //        Internship internshipInFilteredList = model.getFilteredInternshipList()
-    //                .get(INDEX_FIRST_INTERNSHIP.getZeroBased());
-    //        Internship editedInternship = new InternshipBuilder(internshipInFilteredList)
-    //                .withCompanyName(VALID_COMPANY_NAME_OPTIVER).build();
-    //        ModifyCommand modifyCommand = new ModifyCommand(INDEX_FIRST_INTERNSHIP,
-    //                new EditInternshipDescriptorBuilder().withCompanyName(VALID_COMPANY_NAME_OPTIVER).build());
-    //
-    //        String expectedMessage = String.format(
-    //                ModifyCommand.MESSAGE_EDIT_INTERNSHIP_SUCCESS,
-    //                Messages.format(editedInternship));
-    //
-    //        InternshipModel expectedModel = new InternshipModelManager(
-    //                new InternshipBook(model.getInternshipBook()),
-    //                new InternshipUserPrefs());
-    //        expectedModel.setInternship(model.getFilteredInternshipList().get(0), editedInternship);
-    //
-    //        assertInternshipCommandSuccess(modifyCommand, model, expectedMessage, expectedModel);
-    //    }
-
     @Test
     public void execute_duplicateInternshipUnfilteredList_failure() {
         Internship firstInternship = model.getFilteredInternshipList().get(INDEX_FIRST_INTERNSHIP.getZeroBased());

--- a/src/test/java/seedu/address/logic/commands/ModifyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ModifyCommandTest.java
@@ -7,8 +7,10 @@ import static seedu.address.logic.commands.CommandTestUtil.DESC_JANESTREET;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_OPTIVER;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPANY_NAME_JANESTREET;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPANY_NAME_OPTIVER;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DEADLINE_JANESTREET;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_REQUIREMENT_JANESTREET;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ROLE_JANESTREET;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STARTDATE_JANESTREET;
 import static seedu.address.logic.commands.CommandTestUtil.assertInternshipCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertInternshipCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showInternshipAtIndex;
@@ -61,11 +63,13 @@ public class ModifyCommandTest {
         InternshipBuilder internshipInList = new InternshipBuilder(lastInternship);
         Internship editedInternship = internshipInList.withCompanyName(VALID_COMPANY_NAME_JANESTREET)
                 .withRole(VALID_ROLE_JANESTREET)
+                .withDeadline(VALID_DEADLINE_JANESTREET, VALID_STARTDATE_JANESTREET)
                 .withRequirements(VALID_REQUIREMENT_JANESTREET).build();
 
         EditInternshipDescriptor descriptor = new EditInternshipDescriptorBuilder()
                 .withCompanyName(VALID_COMPANY_NAME_JANESTREET)
                 .withRole(VALID_ROLE_JANESTREET)
+                .withDeadline(VALID_DEADLINE_JANESTREET, VALID_STARTDATE_JANESTREET)
                 .withRequirements(VALID_REQUIREMENT_JANESTREET).build();
         ModifyCommand modifyCommand = new ModifyCommand(indexLastInternship, descriptor);
 

--- a/src/test/java/seedu/address/logic/parser/ModifyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ModifyCommandParserTest.java
@@ -37,7 +37,12 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.ModifyCommand;
 import seedu.address.logic.commands.ModifyCommand.EditInternshipDescriptor;
-import seedu.address.model.internship.*;
+import seedu.address.model.internship.ApplicationStatus;
+import seedu.address.model.internship.CompanyName;
+import seedu.address.model.internship.Deadline;
+import seedu.address.model.internship.Duration;
+import seedu.address.model.internship.Role;
+import seedu.address.model.internship.StartDate;
 import seedu.address.model.requirement.Requirement;
 import seedu.address.testutil.EditInternshipDescriptorBuilder;
 
@@ -92,12 +97,10 @@ public class ModifyCommandParserTest {
                 parser,
                 "1" + INVALID_APPLICATION_STATUS_DESC,
                 ApplicationStatus.MESSAGE_CONSTRAINTS); // invalid application status
-
         assertInternshipParseFailure(
                 parser,
                 "1" + INVALID_DEADLINE_DESC,
                 Deadline.MESSAGE_CONSTRAINTS); // invalid deadline
-
         assertInternshipParseFailure(
                 parser,
                 "1" + INVALID_START_DATE_DESC,

--- a/src/test/java/seedu/address/logic/parser/ModifyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ModifyCommandParserTest.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.APPLICATION_STATUS_DESC_JANESTREET;
 import static seedu.address.logic.commands.CommandTestUtil.COMPANY_NAME_DESC_JANESTREET;
 import static seedu.address.logic.commands.CommandTestUtil.COMPANY_NAME_DESC_OPTIVER;
+import static seedu.address.logic.commands.CommandTestUtil.DEADLINE_DESC_JANESTREET;
 import static seedu.address.logic.commands.CommandTestUtil.DURATION_DESC_JANESTREET;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_APPLICATION_STATUS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_COMPANY_NAME_DESC;
@@ -19,8 +20,10 @@ import static seedu.address.logic.commands.CommandTestUtil.ROLE_DESC_OPTIVER;
 import static seedu.address.logic.commands.CommandTestUtil.START_DATE_DESC_JANESTREET;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPLICATIONSTATUS_JANESTREET;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPANY_NAME_JANESTREET;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DEADLINE_JANESTREET;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DURATION_JANESTREET;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_REQUIREMENT_JANESTREET;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_REQUIREMENT_OPTIVER;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ROLE_JANESTREET;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STARTDATE_JANESTREET;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY_NAME;
@@ -29,6 +32,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CommandInternshipParserUtilTest.assertInternshipParseFailure;
 import static seedu.address.logic.parser.CommandInternshipParserUtilTest.assertInternshipParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_INTERNSHIP;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_INTERNSHIP;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_INTERNSHIP;
 
 import org.junit.jupiter.api.Test;
@@ -113,14 +117,10 @@ public class ModifyCommandParserTest {
                 parser,
                 "1" + INVALID_REQUIREMENT_DESC,
                 Requirement.MESSAGE_CONSTRAINTS); // invalid requirement
-
-        // invalid company name followed by valid role
-        /*
         assertInternshipParseFailure(
                 parser,
                 "1" + INVALID_COMPANY_NAME_DESC + ROLE_DESC_JANESTREET,
-      Role.MESSAGE_CONSTRAINTS);
-         */
+                CompanyName.MESSAGE_CONSTRAINTS);
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
         // parsing it together with a valid tag results in error
@@ -136,7 +136,7 @@ public class ModifyCommandParserTest {
         assertInternshipParseFailure(parser, "1" + INVALID_COMPANY_NAME_DESC + INVALID_ROLE_DESC,
                 CompanyName.MESSAGE_CONSTRAINTS);
     }
-    /*
+
     @Test
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_INTERNSHIP;
@@ -155,8 +155,8 @@ public class ModifyCommandParserTest {
         ModifyCommand expectedCommand = new ModifyCommand(targetIndex, descriptor);
 
         assertInternshipParseSuccess(parser, userInput, expectedCommand);
-      }
-     */
+    }
+
 
 
     @Test
@@ -193,12 +193,12 @@ public class ModifyCommandParserTest {
         expectedCommand = new ModifyCommand(targetIndex, descriptor);
         assertInternshipParseSuccess(parser, userInput, expectedCommand);
 
-        //        // deadline
-        //        userInput = targetIndex.getOneBased() + DEADLINE_DESC_JANESTREET;
-        //        descriptor = new EditInternshipDescriptorBuilder()
-        //                .withDeadline(VALID_DEADLINE_JANESTREET, VALID_STARTDATE_JANESTREET).build();
-        //        expectedCommand = new ModifyCommand(targetIndex, descriptor);
-        //        assertInternshipParseSuccess(parser, userInput, expectedCommand);
+        // deadline
+        userInput = targetIndex.getOneBased() + DEADLINE_DESC_JANESTREET;
+        descriptor = new EditInternshipDescriptorBuilder()
+                .withDeadline(VALID_DEADLINE_JANESTREET, VALID_STARTDATE_JANESTREET).build();
+        expectedCommand = new ModifyCommand(targetIndex, descriptor);
+        assertInternshipParseSuccess(parser, userInput, expectedCommand);
 
         // start date
         userInput = targetIndex.getOneBased() + START_DATE_DESC_JANESTREET;
@@ -228,16 +228,16 @@ public class ModifyCommandParserTest {
         Index targetIndex = INDEX_FIRST_INTERNSHIP;
         String userInput = targetIndex.getOneBased() + COMPANY_NAME_DESC_JANESTREET + INVALID_COMPANY_NAME_DESC;
 
-        //        assertInternshipParseFailure(parser, userInput, Messages
-        //              .getErrorMessageForDuplicatePrefixes(PREFIX_COMPANY_NAME));
+        assertInternshipParseFailure(parser, userInput, Messages
+              .getErrorMessageForDuplicatePrefixes(PREFIX_COMPANY_NAME));
 
         // invalid followed by valid
         userInput = targetIndex.getOneBased() + INVALID_COMPANY_NAME_DESC + COMPANY_NAME_DESC_JANESTREET;
 
-        //        assertInternshipParseFailure(
-        //              parser,
-        //              userInput,
-        //              Messages.getErrorMessageForDuplicatePrefixes(PREFIX_COMPANY_NAME));
+        assertInternshipParseFailure(
+              parser,
+              userInput,
+              Messages.getErrorMessageForDuplicatePrefixes(PREFIX_COMPANY_NAME));
 
         // multiple valid fields repeated
         userInput = targetIndex.getOneBased() + COMPANY_NAME_DESC_JANESTREET + COMPANY_NAME_DESC_OPTIVER
@@ -250,18 +250,18 @@ public class ModifyCommandParserTest {
         userInput = targetIndex.getOneBased() + INVALID_ROLE_DESC + INVALID_COMPANY_NAME_DESC
                 + INVALID_ROLE_DESC + INVALID_COMPANY_NAME_DESC;
 
-        //        assertInternshipParseFailure(parser, userInput,
-        //                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ROLE, PREFIX_COMPANY_NAME));
+        assertInternshipParseFailure(parser, userInput,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ROLE, PREFIX_COMPANY_NAME));
     }
 
-    //    @Test
-    //    public void parse_resetRequirements_success() {
-    //        Index targetIndex = INDEX_THIRD_INTERNSHIP;
-    //        String userInput = targetIndex.getOneBased() + REQUIREMENT_EMPTY;
-    //
-    //        EditInternshipDescriptor descriptor = new EditInternshipDescriptorBuilder()
-    //                .withRequirements().build();
-    //        ModifyCommand expectedCommand = new ModifyCommand(targetIndex, descriptor);
-    //        assertInternshipParseSuccess(parser, userInput, expectedCommand);
-    //    }
+    @Test
+    public void parse_resetRequirements_failure() {
+        Index targetIndex = INDEX_THIRD_INTERNSHIP;
+        String userInput = targetIndex.getOneBased() + REQUIREMENT_EMPTY;
+
+        EditInternshipDescriptor descriptor = new EditInternshipDescriptorBuilder()
+                .withRequirements().build();
+        ModifyCommand expectedCommand = new ModifyCommand(targetIndex, descriptor);
+        assertInternshipParseFailure(parser, userInput, Requirement.MESSAGE_CONSTRAINTS);
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/ModifyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ModifyCommandParserTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.COMPANY_NAME_DESC_OPT
 import static seedu.address.logic.commands.CommandTestUtil.DURATION_DESC_JANESTREET;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_APPLICATION_STATUS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_COMPANY_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_DEADLINE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DURATION_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_REQUIREMENT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ROLE_DESC;
@@ -36,11 +37,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.ModifyCommand;
 import seedu.address.logic.commands.ModifyCommand.EditInternshipDescriptor;
-import seedu.address.model.internship.ApplicationStatus;
-import seedu.address.model.internship.CompanyName;
-import seedu.address.model.internship.Duration;
-import seedu.address.model.internship.Role;
-import seedu.address.model.internship.StartDate;
+import seedu.address.model.internship.*;
 import seedu.address.model.requirement.Requirement;
 import seedu.address.testutil.EditInternshipDescriptorBuilder;
 
@@ -96,12 +93,10 @@ public class ModifyCommandParserTest {
                 "1" + INVALID_APPLICATION_STATUS_DESC,
                 ApplicationStatus.MESSAGE_CONSTRAINTS); // invalid application status
 
-        /*
         assertInternshipParseFailure(
                 parser,
                 "1" + INVALID_DEADLINE_DESC,
                 Deadline.MESSAGE_CONSTRAINTS); // invalid deadline
-         */
 
         assertInternshipParseFailure(
                 parser,

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -1,0 +1,159 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.internship.ApplicationStatus;
+import seedu.address.model.internship.CompanyName;
+import seedu.address.model.internship.Deadline;
+import seedu.address.model.internship.Duration;
+import seedu.address.model.internship.Role;
+import seedu.address.model.internship.StartDate;
+import seedu.address.model.requirement.Requirement;
+
+class ParserUtilTest {
+
+    @Test
+    void testParseIndex_valid() throws ParseException {
+        assertEquals(1, ParserUtil.parseIndex("1").getOneBased());
+        assertEquals(2, ParserUtil.parseIndex("  2  ").getOneBased());
+    }
+
+    @Test
+    void testParseIndex_invalid() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseIndex("0"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseIndex("-1"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseIndex("a"));
+    }
+
+    @Test
+    void testParseCompanyName_valid() throws ParseException {
+        String input = "Google";
+        CompanyName companyName = ParserUtil.parseCompanyName(input);
+        assertEquals("Google", companyName.toString());
+    }
+
+    @Test
+    void testParseCompanyName_invalid() {
+        String input = ""; // Assuming empty company name is invalid
+        assertThrows(ParseException.class, () -> ParserUtil.parseCompanyName(input));
+    }
+
+    @Test
+    void testParseRole_valid() throws ParseException {
+        String input = "Developer";
+        Role role = ParserUtil.parseRole(input);
+        assertEquals("Developer", role.toString());
+    }
+
+    @Test
+    void testParseRole_invalid() {
+        String input = ""; // Assuming empty role is invalid
+        assertThrows(ParseException.class, () -> ParserUtil.parseRole(input));
+    }
+
+    @Test
+    void testParseApplicationStatus_valid() throws ParseException {
+        String input = "Yet to apply";
+        ApplicationStatus status = ParserUtil.parseApplicationStatus(input);
+        assertEquals("Yet to apply", status.toString());
+    }
+
+    @Test
+    void testParseApplicationStatus_invalid() {
+        String input = "Not a status";
+        assertThrows(ParseException.class, () -> ParserUtil.parseApplicationStatus(input));
+    }
+
+    @Test
+    void testParseDeadline_withStartDate_valid() throws ParseException {
+        String deadline = "01/01/2023";
+        String startDate = "01/01/2024";
+        Deadline result = ParserUtil.parseDeadline(deadline, startDate);
+        assertEquals("01/01/2023", result.toString());
+    }
+
+    @Test
+    void testParseDeadline_withStartDate_invalid() {
+        String deadline = "invalid date";
+        String startDate = "01/01/2022";
+        assertThrows(ParseException.class, () -> ParserUtil.parseDeadline(deadline, startDate));
+    }
+
+    @Test
+    void testParseDeadline_single_valid() throws ParseException {
+        String deadline = "01/01/2023";
+        Deadline result = ParserUtil.parseDeadline(deadline);
+        assertEquals("01/01/2023", result.toString());
+    }
+
+    @Test
+    void testParseDeadline_single_invalid() {
+        String deadline = "02/01/2023";
+        String startDate = "01/01/2023";
+        assertThrows(ParseException.class, () -> ParserUtil.parseDeadline(deadline, startDate));
+    }
+
+    @Test
+    void testParseStartDate_valid() throws ParseException {
+        String input = "01/01/2022";
+        StartDate startDate = ParserUtil.parseStartDate(input);
+        assertEquals("01/01/2022", startDate.toString());
+    }
+
+    @Test
+    void testParseStartDate_invalid() {
+        String input = "invalid date";
+        assertThrows(ParseException.class, () -> ParserUtil.parseStartDate(input));
+    }
+
+    @Test
+    void testParseDuration_valid() throws ParseException {
+        String input = "6";
+        Duration duration = ParserUtil.parseDuration(input);
+        assertEquals("6", duration.toString());
+    }
+
+    @Test
+    void testParseDuration_invalid() {
+        String input = "forever";
+        assertThrows(ParseException.class, () -> ParserUtil.parseDuration(input));
+    }
+
+    @Test
+    void testParseRequirements_valid() throws ParseException {
+        Set<String> input = new HashSet<>(Arrays.asList("Java", "Python"));
+        Set<Requirement> result = ParserUtil.parseRequirements(input);
+        assertTrue(result.stream().anyMatch(r -> r.toString().equals("[Java]")));
+        assertTrue(result.stream().anyMatch(r -> r.toString().equals("[Python]")));
+    }
+
+    @Test
+    void testParseRequirements_invalid() {
+        Set<String> input = new HashSet<>(Collections.singletonList(""));
+        assertThrows(ParseException.class, () -> ParserUtil.parseRequirements(input));
+    }
+
+    @Test
+    void testParseRequirement_valid() throws ParseException {
+        String input = "Java";
+        Requirement requirement = ParserUtil.parseRequirement(input);
+        assertEquals("[Java]", requirement.toString());
+    }
+
+    @Test
+    void testParseRequirement_invalid() {
+        String input = ""; // Assuming empty requirement name is invalid
+        assertThrows(ParseException.class, () -> ParserUtil.parseRequirement(input));
+    }
+}
+

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -21,7 +21,6 @@ import seedu.address.model.internship.StartDate;
 import seedu.address.model.requirement.Requirement;
 
 class ParserUtilTest {
-
     @Test
     void testParseIndex_valid() throws ParseException {
         assertEquals(1, ParserUtil.parseIndex("1").getOneBased());


### PR DESCRIPTION
The previous code for modify did not include a check to determine if the deadline is before the start date, which might be an issue since users would want to be notified if the edited start date or deadline is invalid.

I was unable to catch the error at the parser level due to lack of access to the model and stored data; hence, the error is now being checked at the command level. At the parser level, a dummy deadline is created with a start date that always comes after the deadline, which is the last day of the same year. However, this dummy data is removed at the command level when there is access to existing data.

I have edited the test cases to support the latest changes.

I also fixed some minor UI bugs, the issues of which are attached to this PR.