### PR TITLE
modified logic part of DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -42,7 +42,7 @@ Given below is a quick overview of main components and how they interact with ea
 The bulk of the app's work is done by the following four components:
 
 * [**`UI`**](#ui-component): The UI of the App.
-* [**`Logic`**](#logic-component): The command executor.
+* [**`InternshipLogic`**](#internshiplogic-component): The command executor.
 * [**`Model`**](#model-component): Holds the data of the App in memory.
 * [**`Storage`**](#storage-component): Reads data from, and writes data to, the hard disk.
 
@@ -77,22 +77,22 @@ The `UI` component uses the JavaFx UI framework. The layout of these UI parts ar
 
 The `UI` component,
 
-* executes user commands using the `Logic` component.
+* executes user commands using the `InternshipLogic` component.
 * listens for changes to `Model` data so that the UI can be updated with the modified data.
-* keeps a reference to the `Logic` component, because the `UI` relies on the `Logic` to execute commands.
+* keeps a reference to the `InternshipLogic` component, because the `UI` relies on the `InternshipLogic` to execute commands.
 * depends on some classes in the `Model` component, as it displays `Internship` object residing in the `Model`.
 
-### Logic component
+### InternshipLogic component
 
 **API** : [`InternshipLogic.java`](https://github.com/AY2324S1-CS2103T-W17-1/tp/blob/master/src/main/java/seedu/address/logic/InternshipLogic.java)
 
-Here's a (partial) class diagram of the `Logic` component:
+Here's a (partial) class diagram of the `InternshipLogic` component:
 
 <puml src="diagrams/LogicClassDiagram.puml" width="550"/>
 
-The sequence diagram below illustrates the interactions within the `Logic` component, taking `execute("delete 1")` API call as an example.
+The sequence diagram below illustrates the interactions within the `InternshipLogic` component, taking `execute("delete 1")` API call as an example.
 
-<puml src="diagrams/DeleteSequenceDiagram.puml" alt="Interactions Inside the Logic Component for the `delete 1` Command" />
+<puml src="diagrams/DeleteSequenceDiagram.puml" alt="Interactions Inside the InternshipLogic Component for the `delete 1` Command" />
 
 <box type="info" seamless>
 
@@ -104,9 +104,9 @@ How the `Logic` component works:
 1. When `InternshipLogic` is called upon to execute a command, it is passed to an `InternshipBookParser` object which in turn creates a parser that matches the command (e.g., `DeleteCommandParser`) and uses it to parse the command.
 1. This results in an `InternshipCommand` object (more precisely, an object of one of its subclasses e.g., `DeleteCommand`) which is executed by the `InternshipLogicManager`.
 1. The command can communicate with the `InternshipModel` when it is executed (e.g. to delete an internship).
-1. The result of the command execution is encapsulated as a `CommandResult` object which is returned back from `Logic`.
+1. The result of the command execution is encapsulated as a `CommandResult` object which is returned back from `InternshipLogic`.
 
-Here are the other classes in `Logic` (omitted from the class diagram above) that are used for parsing a user command:
+Here are the other classes in `InternshipLogic` (omitted from the class diagram above) that are used for parsing a user command:
 
 <puml src="diagrams/ParserClasses.puml" width="600"/>
 
@@ -260,7 +260,7 @@ Step 3. The selected internship entry is deleted.
 
 The following sequence diagram shows how the delete operation works:
 
-<puml src="diagrams/DeleteSequenceDiagram.puml" alt="Interactions Inside the Logic Component for the `delete 1` Command" />
+<puml src="diagrams/DeleteSequenceDiagram.puml" alt="Interactions Inside the InternshipLogic Component for the `delete 1` Command" />
 
 <box type="info" seamless>
 

--- a/docs/diagrams/DeleteSequenceDiagram.puml
+++ b/docs/diagrams/DeleteSequenceDiagram.puml
@@ -2,7 +2,7 @@
 !include style.puml
 skinparam ArrowFontStyle plain
 
-box Logic LOGIC_COLOR_T1
+box InternshipLogic LOGIC_COLOR_T1
 participant ":InternshipLogicManager" as InternshipLogicManager LOGIC_COLOR
 participant ":InternshipBookParser" as InternshipBookParser LOGIC_COLOR
 participant ":DeleteCommandParser" as DeleteCommandParser LOGIC_COLOR

--- a/docs/diagrams/LogicClassDiagram.puml
+++ b/docs/diagrams/LogicClassDiagram.puml
@@ -1,19 +1,20 @@
 @startuml
 !include style.puml
+!pragma layout smetana
 skinparam arrowThickness 1.1
 skinparam arrowColor LOGIC_COLOR_T4
 skinparam classBackgroundColor LOGIC_COLOR
 
-package Logic as LogicPackage {
+package InternshipLogic as InternshipLogicPackage {
 
-Class AddressBookParser
+Class InternshipParser
 Class XYZCommand
 Class CommandResult
-Class "{abstract}\nCommand" as Command
+Class "{abstract}\nInternshipCommand" as InternshipCommand
 
 
-Class "<<interface>>\nLogic" as Logic
-Class LogicManager
+Class "<<interface>>\nInternshipLogic" as InternshipLogic
+Class InternshipLogicManager
 }
 
 package Model {
@@ -24,23 +25,23 @@ package Storage {
 }
 
 Class HiddenOutside #FFFFFF
-HiddenOutside ..> Logic
+HiddenOutside ..> InternshipLogic
 
-LogicManager .right.|> Logic
-LogicManager -right->"1" AddressBookParser
-AddressBookParser ..> XYZCommand : creates >
+InternshipLogicManager .right.|> InternshipLogic
+InternshipLogicManager -right->"1" InternshipBookParser
+InternshipBookParser ..> XYZCommand : creates >
 
-XYZCommand -up-|> Command
-LogicManager .left.> Command : executes >
+XYZCommand -up-|> InternshipCommand
+InternshipLogicManager .left.> InternshipCommand : executes >
 
-LogicManager --> Model
-LogicManager --> Storage
+InternshipLogicManager --> Model
+InternshipLogicManager --> Storage
 Storage --[hidden] Model
-Command .[hidden]up.> Storage
-Command .right.> Model
-note right of XYZCommand: XYZCommand = AddCommand, \nFindCommand, etc
+InternshipCommand .[hidden]up.> Storage
+InternshipCommand .right.> Model
+note right of XYZCommand: XYZCommand = CreateCommand, \nFilterCommand, etc
 
-Logic ..> CommandResult
-LogicManager .down.> CommandResult
-Command .up.> CommandResult : produces >
+InternshipLogic ..> CommandResult
+InternshipLogicManager .down.> CommandResult
+InternshipCommand .up.> CommandResult : produces >
 @enduml


### PR DESCRIPTION
The previous UML logic used 'logic' instead of 'internshipLogic', and many classes were still from AB3. Updated to ensure consistency with the internship workflow.