### PR TITLE
Fix Create Command UML diagram problems

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -175,7 +175,7 @@ the other corresponding command.
 
 </box>
 
-Step 2. The `create` command is executed. If there does not exist a duplicate entry in `InternshipStorage`, the internship
+Step 2. The `create` command is executed. If there does not exist a duplicate entry in `InternshipModel`, the internship
 entry is created successfully.
 
 <puml src="diagrams/CreateCommandExecute.puml" alt="CreateCommandExecute" />
@@ -186,11 +186,11 @@ entry is created successfully.
 
 </box>
 
-Step 3. The internship entry is stored in `InternshipStorage`.
+Step 3. `InternshipStorage` now updates the stored internship entry list using the updated values in `ReadOnlyInternshipBook`.
 
 <puml src="diagrams/CreateCommandStore.puml" alt="CreateCommandStore" />
 
-The following sequence diagram shows how the create command operation works:
+The following sequence diagram shows how the `create` command operation works:
 
 <puml src="diagrams/CreateSequenceDiagram.puml" alt="CreateSequenceDiagram" />
 

--- a/docs/diagrams/CreateCommandExecute.puml
+++ b/docs/diagrams/CreateCommandExecute.puml
@@ -18,9 +18,7 @@ package "Command" {
     class CreateCommand as "CreateCommand"
 }
 
-CreateCommand - InternshipLogicManager: executes <
-CreateCommand - InternshipModel : stores if entry not duplicate <
-InternshipModel -[hidden]up-> CreateCommand
-
+InternshipLogicManager -down- CreateCommand : > executes
+CreateCommand -up- InternshipModel : < checks if duplicate entry exists\nand creates new entry if unique
 
 @enduml

--- a/docs/diagrams/CreateCommandParse.puml
+++ b/docs/diagrams/CreateCommandParse.puml
@@ -14,6 +14,6 @@ hide CreateCommand
 
 class UserInput as "create c/Google ro/SWE..."
 
-UserInput - InternshipBookParser : < parses
+UserInput -up- InternshipBookParser : < parses
 
 @enduml

--- a/docs/diagrams/CreateCommandStore.puml
+++ b/docs/diagrams/CreateCommandStore.puml
@@ -6,18 +6,16 @@ skinparam ClassBackgroundColor #FFFFAA
 
 title Internship Entry Storage Stage
 
+package "Model" {
+    class InternshipModel as "InternshipModel"
+}
+
 package "Storage" {
     class InternshipStorage as "InternshipStorage"
 }
 
-class InternshipEntry as "InternshipEntry:\nJane Street, Coffee maker"
-
-InternshipStorage -[hidden]right-> InternshipEntry
-
-hide InternshipEntry
-
-class Internship as "Internship"
-
-InternshipStorage - Internship : stores >
+class ReadOnlyInternshipBook as "ReadOnlyInternshipBook"
+ReadOnlyInternshipBook -up- InternshipModel: < Retrieves
+ReadOnlyInternshipBook -up- InternshipStorage : < Uses to update storage
 
 @enduml

--- a/docs/diagrams/CreateSequenceDiagram.puml
+++ b/docs/diagrams/CreateSequenceDiagram.puml
@@ -14,6 +14,10 @@ box Model MODEL_COLOR_T1
 participant ":InternshipModel" as InternshipModel MODEL_COLOR
 end box
 
+box Storage STORAGE_COLOR_T1
+participant ":InternshipStorage" as Storage STORAGE_COLOR
+end box
+
 [-> InternshipLogicManager : execute("create c/Google ro/SWE ...")
 activate InternshipLogicManager
 
@@ -65,6 +69,18 @@ deactivate CommandResult
 CreateCommand --> InternshipLogicManager : commandResult
 
 deactivate CreateCommand
+
+InternshipLogicManager -> InternshipModel : getInternshipBook()
+activate InternshipModel
+
+InternshipModel --> InternshipLogicManager : internshipBook
+deactivate InternshipModel
+
+InternshipLogicManager -> Storage : saveInternshipBook(internshipBook)
+activate Storage
+
+Storage --> InternshipLogicManager
+deactivate Storage
 
 [<--InternshipLogicManager
 deactivate InternshipLogicManager

--- a/docs/team/jinyang628.md
+++ b/docs/team/jinyang628.md
@@ -5,7 +5,7 @@ title: "Chen Jin Yang's Project Portfolio Page"
 
 ## Project: Flagship
 
-Flagship is a desktop application used to help aspiring students track internship applications. The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java, and has about () kLoC.
+Flagship is a desktop application used to help aspiring students track internship applications. The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java.
 
 ## Summary of contributions
 

--- a/docs/team/jinyang628.md
+++ b/docs/team/jinyang628.md
@@ -13,7 +13,7 @@ Flagship is a desktop application used to help aspiring students track internshi
     * Refactored the AB3 models and interfaces so that they can be repurposed for Flagship
         * E.g. Adding new parameters, renaming interfaces, etc.
     * Oversaw the development of the Create Command, which allows users to key in internship details into Flagship.
-    * Overall in charge of the following files
+    * Overall in charge of the following files (test files not listed)
       * ApplicationStatus.java
       * CompanyName.java
       * Deadline.java
@@ -26,15 +26,6 @@ Flagship is a desktop application used to help aspiring students track internshi
       * ParserUtil.java
       * CreateCommand.java
       * UniqueInternshipList.java
-      * DeadlineTest.java
-      * InternshipTest.java
-      * RequirementTest.java
-      * CreateCommandTest.java
-      * InternshipStorageManagerTest.java
-      * JsonAdaptedInternshipTest.java
-      * JsonInternshipBookStorageTest.java
-      * JsonSerializableInternshipBookTest.java
-      * JsonInternshipUserPrefsStorageTest.java
     * Wrote test cases to comprehensively test the Create Command
     * [RepoSense link](https://nus-cs2103-ay2324s1.github.io/tp-dashboard/?search=&sort=groupTitle&sortWithin=title&timeframe=commit&mergegroup=&groupSelect=groupByRepos&breakdown=true&checkedFileTypes=docs~functional-code~test-code&since=2023-09-22&tabOpen=true&tabType=authorship&tabAuthor=jinyang628&tabRepo=AY2324S1-CS2103T-W17-1%2Ftp%5Bmaster%5D&authorshipIsMergeGroup=false&authorshipFileTypes=docs~functional-code~test-code&authorshipIsBinaryFileTypeChecked=false&authorshipIsIgnoredFilesChecked=false)
 

--- a/docs/team/jinyang628.md
+++ b/docs/team/jinyang628.md
@@ -45,7 +45,7 @@ Flagship is a desktop application used to help aspiring students track internshi
       * Internship requirements are extremely flexible (users can input any number of requirements)
       * Internship details can be keyed in any order
       * Purposeful equality definition that strikes a balance between error detection and user flexibility 
-    * (Pull requests [\#19](https://github.com/AY2324S1-CS2103T-W17-1/tp/pull/19), [\#75](https://github.com/AY2324S1-CS2103T-W17-1/tp/pull/75))
+    * Pull requests [\#19](https://github.com/AY2324S1-CS2103T-W17-1/tp/pull/19), [\#75](https://github.com/AY2324S1-CS2103T-W17-1/tp/pull/75)
 
 * **Documentation**:
   * User Guide:
@@ -69,10 +69,10 @@ Flagship is a desktop application used to help aspiring students track internshi
     [\#195](https://github.com/AY2324S1-CS2103T-W17-1/tp/pull/195),
     [\#199](https://github.com/AY2324S1-CS2103T-W17-1/tp/pull/199),
     [\#200](https://github.com/AY2324S1-CS2103T-W17-1/tp/pull/200),
-  * [\#213](https://github.com/AY2324S1-CS2103T-W17-1/tp/pull/213)
+    [\#213](https://github.com/AY2324S1-CS2103T-W17-1/tp/pull/213)
   * Reported bugs and suggestions for other teams in the class:
     [\#9](https://github.com/jinyang628/ped/issues/9),
     [\#7](https://github.com/jinyang628/ped/issues/7)
 
 * **Tools**:
-  * Utilised 'org.junit.jupiter:junit-jupiter-params:5.7.0' to reduce code duplications in test cases
+  * Utilised `org.junit.jupiter:junit-jupiter-params:5.7.0` to reduce code duplications in test cases


### PR DESCRIPTION
Currently, the formatting of the Create Command UML diagrams is bad.

Correct formatting is important in ensuring visual clarity.

Fix the order of the classes in the UML diagrams.

Fixes #251 
Fixes #246 