### PR TITLE
Modify parsing logic to handle spaces

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -564,8 +564,11 @@ Flagship data is saved automatically as a [JSON](#glossary) file `[JAR file loca
 Advanced users are welcome to update data directly by editing that data file.
 
 <div markdown="span" class="alert alert-danger">
-⚠️ If your changes to the data file make it invalid, such as incorrect formatting (e.g. extra spaces) or duplicate internship entries, Flagship will discard all data and start with an empty data file at the next run.
-Hence, it is recommended to take a backup of the file before editing it.
+⚠️ Be extremely careful if you make any changes to the data file. If you make incorrect formatting changes or insert duplicate internship entries,
+Flagship will discard all data and start with an empty data file on the next run. If you add extra spaces in the parameters (e.g. company name 
+or role), we will not be able to remove the spaces effectively. This will adversely affect what is displayed on the GUI. 
+
+Hence, you are highly recommended to take a backup of the file before editing it.
 </div>
 
 <div markdown="span" class="alert alert-danger">

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -310,11 +310,12 @@ that you do not accidentally track an internship application twice. The followin
 </div>
 <br>
 
-| Description                                                                                           | Example                                                                   |
-|-------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
-| **Company names/roles only differ in upper/lower cases**                                              | `Jane Street`, `jane Street` and `jANe strEEt` are considered the same    |
-| **Company names/roles only differ in leading/trailing white spaces** (Using dots to represent spaces) | `...Jane Street`, `Jane Street...`, `Jane Street` are considered the same |
-| **Combination of differences only in upper/lower cases and leading/trailing white spaces**            | `Jane street...`, `...jane StReet` are considered the same                |
+| Description                                                                                                    | Example                                                                   |
+|----------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
+| **Company names/roles only differ in upper/lower cases**                                                       | `Jane Street`, `jane Street` and `jANe strEEt` are considered the same    |
+| **Company names/roles only differ in leading/trailing white spaces** (Using dots to represent spaces)          | `...Jane Street`, `Jane Street...`, `Jane Street` are considered the same |
+| **Company names/roles only differ in number of internal white spaces** (Flagship trims excess internal spaces) | `Jane    Street`, `Jane Street` are considered the same                   |
+| **Combination of the differences mentioned above**                                                             | `Jane street...`, `...jane StReet` are considered the same                |
 
 **All other differences** between two internship entries' company name and role will cause them to be considered as distinct entries.
 
@@ -563,7 +564,7 @@ Flagship data is saved automatically as a [JSON](#glossary) file `[JAR file loca
 Advanced users are welcome to update data directly by editing that data file.
 
 <div markdown="span" class="alert alert-danger">
-⚠️ If your changes to the data file make it invalid, such as adding invalid formatting or duplicate internship entries, Flagship will discard all data and start with an empty data file at the next run.
+⚠️ If your changes to the data file make it invalid, such as incorrect formatting (e.g. extra spaces) or duplicate internship entries, Flagship will discard all data and start with an empty data file at the next run.
 Hence, it is recommended to take a backup of the file before editing it.
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -566,7 +566,7 @@ Advanced users are welcome to update the data file directly by editing **interns
 <div markdown="span" class="alert alert-danger">
 
 ⚠️  **Be extremely careful if you make any changes to the data file!**
-- If you make incorrect formatting changes, insert duplicate internship entries, or give invalid values to certain parameters, 
+- If you make incorrect formatting changes, insert duplicate internship entries, or give [invalid values](#parameter-constraints) to certain parameters, 
   Flagship will discard all data and start with an empty data file on the next run.
 - If you add extra spaces in the parameters (e.g. company name or role), we will not be able to remove the spaces effectively. This will adversely affect what is displayed on the GUI.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -561,15 +561,19 @@ Flagship data is saved automatically as a [JSON](#glossary) file `[JAR file loca
 
 ## Editing the data file
 
-Advanced users are welcome to update data directly by editing that data file.
+Advanced users are welcome to update the data file directly by editing **internshipBook.json**.
 
 <div markdown="span" class="alert alert-danger">
-⚠️ Be extremely careful if you make any changes to the data file. If you make incorrect formatting changes or insert duplicate internship entries,
-Flagship will discard all data and start with an empty data file on the next run. If you add extra spaces in the parameters (e.g. company name 
-or role), we will not be able to remove the spaces effectively. This will adversely affect what is displayed on the GUI. 
+
+⚠️  **Be extremely careful if you make any changes to the data file!**
+- If you make incorrect formatting changes, insert duplicate internship entries, or give invalid values to certain parameters, 
+  Flagship will discard all data and start with an empty data file on the next run.
+- If you add extra spaces in the parameters (e.g. company name or role), we will not be able to remove the spaces effectively. This will adversely affect what is displayed on the GUI.
 
 Hence, you are highly recommended to take a backup of the file before editing it.
 </div>
+
+
 
 <div markdown="span" class="alert alert-danger">
 ⚠️ Flagship is not optimised to handle excessively large number of internship entries — we believe that it is extremely rare for you 

--- a/src/main/java/seedu/address/logic/parser/CreateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateCommandParser.java
@@ -56,8 +56,12 @@ public class CreateCommandParser implements InternshipParser<CreateCommand> {
         // There should be at least 6 parameters tokenized (because requirements are optional)
         assert(argMultimap.getLength() >= 6);
 
-        CompanyName companyName = ParserUtil.parseCompanyName(argMultimap.getValue(PREFIX_COMPANY_NAME).get().strip());
-        Role role = ParserUtil.parseRole(argMultimap.getValue(PREFIX_ROLE).get().strip());
+        CompanyName companyName = ParserUtil.parseCompanyName(
+                argMultimap.getValue(PREFIX_COMPANY_NAME).get().strip().replaceAll("\\s+", " ")
+        );
+        Role role = ParserUtil.parseRole(
+                argMultimap.getValue(PREFIX_ROLE).get().strip().replaceAll("\\s+", " ")
+        );
 
         ApplicationStatus applicationStatus = ParserUtil.parseApplicationStatus(
                 argMultimap.getValue(PREFIX_APPLICATION_STATUS).get().strip()

--- a/src/main/java/seedu/address/model/internship/ApplicationStatus.java
+++ b/src/main/java/seedu/address/model/internship/ApplicationStatus.java
@@ -34,13 +34,16 @@ public class ApplicationStatus implements Comparable<ApplicationStatus> {
     }
 
     /**
-     * Verifies whether the given string constitutes a valid application status enum.
+     * Verifies whether the given string constitutes a valid application status enum. The given string is also stripped
+     * to defensively guard against instances where leading or trailing spaces are inserted when user directly modifies
+     * the internship.json file. This is important so that the given string does not fail the regex check.
      *
      * @param test The given string to be tested.
      * @return A boolean representing whether the string input is valid.
      */
     public static boolean isValidApplicationStatus(String test) {
-        return VALID_STATUSES.contains(test);
+        String strippedTest = test.strip();
+        return VALID_STATUSES.contains(strippedTest);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/internship/CompanyName.java
+++ b/src/main/java/seedu/address/model/internship/CompanyName.java
@@ -60,7 +60,10 @@ public class CompanyName implements Comparable<CompanyName> {
         }
 
         CompanyName otherCompanyName = (CompanyName) other;
-        return this.companyName.equalsIgnoreCase(otherCompanyName.companyName);
+        return this.companyName
+                .strip()
+                .replaceAll("\\s+", " ")
+                .equalsIgnoreCase(otherCompanyName.companyName);
     }
 
     /**

--- a/src/main/java/seedu/address/model/internship/CompanyName.java
+++ b/src/main/java/seedu/address/model/internship/CompanyName.java
@@ -31,16 +31,19 @@ public class CompanyName implements Comparable<CompanyName> {
 
     /**
      * Verifies whether the given string constitutes a valid company name. Company names longer than 200 characters
-     * are rejected to prevent overflows in the UI.
+     * are rejected to prevent overflows in the UI. The given string is also stripped to defensively guard against
+     * instances where leading or trailing spaces are inserted when user directly modifies the internship.json file.
+     * This is important so that the given string does not fail the regex check.
      *
      * @param test The given string to be tested.
      * @return A boolean representing whether the string input is valid.
      */
     public static boolean isValidCompanyName(String test) {
-        if (test.length() > 200) {
+        String strippedTest = test.strip();
+        if (strippedTest.length() > 200) {
             return false;
         }
-        return test.matches(VALIDATION_REGEX);
+        return strippedTest.matches(VALIDATION_REGEX);
     }
 
     @Override
@@ -69,14 +72,14 @@ public class CompanyName implements Comparable<CompanyName> {
         CompanyName otherCompanyName = (CompanyName) other;
 
 
-        String thisCompanyNameStringStripped = this.companyName
+        String thisStrippedCompanyNameString = this.companyName
                 .strip()
                 .replaceAll("\\s+", " ");
-        String otherCompanyNameStringStripped = otherCompanyName.companyName
+        String otherStrippedCompanyNameString = otherCompanyName.companyName
                 .strip()
                 .replaceAll("\\s+", " ");
 
-        return thisCompanyNameStringStripped.equalsIgnoreCase(otherCompanyNameStringStripped);
+        return thisStrippedCompanyNameString.equalsIgnoreCase(otherStrippedCompanyNameString);
     }
 
     /**

--- a/src/main/java/seedu/address/model/internship/CompanyName.java
+++ b/src/main/java/seedu/address/model/internship/CompanyName.java
@@ -48,6 +48,13 @@ public class CompanyName implements Comparable<CompanyName> {
         return this.companyName;
     }
 
+    /**
+     * Verifies whether this company name is equals to the given object. This block of code defensively guard against
+     * duplicate company names that only differ in terms of the number of leading, trailing or internal spaces. It is
+     * especially important in cases where users edit the internship.json file directly.
+     * @param other The given object to check for equality against.
+     * @return A boolean representing whether this company name is equals to the object.
+     */
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -60,10 +67,16 @@ public class CompanyName implements Comparable<CompanyName> {
         }
 
         CompanyName otherCompanyName = (CompanyName) other;
-        return this.companyName
+
+
+        String thisCompanyNameStringStripped = this.companyName
                 .strip()
-                .replaceAll("\\s+", " ")
-                .equalsIgnoreCase(otherCompanyName.companyName);
+                .replaceAll("\\s+", " ");
+        String otherCompanyNameStringStripped = otherCompanyName.companyName
+                .strip()
+                .replaceAll("\\s+", " ");
+
+        return thisCompanyNameStringStripped.equalsIgnoreCase(otherCompanyNameStringStripped);
     }
 
     /**

--- a/src/main/java/seedu/address/model/internship/Deadline.java
+++ b/src/main/java/seedu/address/model/internship/Deadline.java
@@ -38,15 +38,19 @@ public class Deadline implements Comparable<Deadline> {
 
     /**
      * Returns true if the given strings for deadline and start date are valid and the deadline is earlier than the
-     * start date.
+     * start date. The given strings are also stripped to defensively guard against instances where leading or trailing
+     * spaces are inserted when user directly modifies the internship.json file. This is important so that the given
+     * strings do not fail the regex check.
      *
      * @param deadlineTest The deadline string to be tested.
      * @param startDateTest The start date string to be tested.
      */
     public static boolean isValidDeadline(String deadlineTest, String startDateTest) {
+        String strippedDeadlineTest = deadlineTest.strip();
+        String strippedStartDateTest = startDateTest.strip();
         try {
-            LocalDate deadline = LocalDate.parse(deadlineTest, DATE_FORMATTER);
-            LocalDate startDate = LocalDate.parse(startDateTest, DATE_FORMATTER);
+            LocalDate deadline = LocalDate.parse(strippedDeadlineTest, DATE_FORMATTER);
+            LocalDate startDate = LocalDate.parse(strippedStartDateTest, DATE_FORMATTER);
             return deadline.isBefore(startDate);
         } catch (DateTimeParseException e) {
             return false;

--- a/src/main/java/seedu/address/model/internship/Duration.java
+++ b/src/main/java/seedu/address/model/internship/Duration.java
@@ -28,13 +28,16 @@ public class Duration implements Comparable<Duration> {
     }
 
     /**
-     * Verifies whether the given string constitutes a valid duration.
+     * Verifies whether the given string constitutes a valid duration. The given string is also stripped to defensively
+     * guard against instances where leading or trailing spaces are inserted when user directly modifies the
+     * internship.json file. This is important so that the given string does not fail the regex check.
      *
      * @param test The given string to be tested.
      * @return A boolean representing whether the string input is valid.
      */
     public static boolean isValidDuration(String test) {
-        return test.matches(VALIDATION_REGEX);
+        String strippedTest = test.strip();
+        return strippedTest.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/internship/Role.java
+++ b/src/main/java/seedu/address/model/internship/Role.java
@@ -60,7 +60,10 @@ public class Role implements Comparable<Role> {
         }
 
         Role otherRole = (Role) other;
-        return this.role.equalsIgnoreCase(otherRole.role);
+        return this.role
+                .strip()
+                .replaceAll("\\s+", " ")
+                .equalsIgnoreCase(otherRole.role);
     }
 
     /**

--- a/src/main/java/seedu/address/model/internship/Role.java
+++ b/src/main/java/seedu/address/model/internship/Role.java
@@ -48,6 +48,13 @@ public class Role implements Comparable<Role> {
         return this.role;
     }
 
+    /**
+     * Verifies whether this role is equals to the given object. This block of code defensively guard against
+     * duplicate roles that only differ in terms of the number of leading, trailing or internal spaces. It is
+     * especially important in cases where users edit the internship.json file directly.
+     * @param other The given object to check for equality against.
+     * @return A boolean representing whether this role is equals to the object.
+     */
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -60,10 +67,16 @@ public class Role implements Comparable<Role> {
         }
 
         Role otherRole = (Role) other;
-        return this.role
+
+        String thisRoleStringStripped = this.role
                 .strip()
-                .replaceAll("\\s+", " ")
-                .equalsIgnoreCase(otherRole.role);
+                .replaceAll("\\s+", " ");
+        String otherRoleStringStripped = otherRole.role
+                .strip()
+                .replaceAll("\\s+", " ");
+
+
+        return thisRoleStringStripped.equalsIgnoreCase(otherRoleStringStripped);
     }
 
     /**

--- a/src/main/java/seedu/address/model/internship/Role.java
+++ b/src/main/java/seedu/address/model/internship/Role.java
@@ -31,16 +31,19 @@ public class Role implements Comparable<Role> {
 
     /**
      * Verifies whether the given string constitutes a valid role. Roles longer than 200 characters are rejected to
-     * prevent overflows in the UI.
+     * prevent overflows in the UI. The given string is also stripped to defensively guard against
+     * instances where leading or trailing spaces are inserted when user directly modifies the internship.json file.
+     * This is important so that the given string does not fail the regex check.
      *
      * @param test The given string to be tested.
      * @return A boolean representing whether the string input is valid.
      */
     public static boolean isValidRole(String test) {
-        if (test.length() > 200) {
+        String strippedTest = test.strip();
+        if (strippedTest.length() > 200) {
             return false;
         }
-        return test.matches(VALIDATION_REGEX);
+        return strippedTest.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/internship/StartDate.java
+++ b/src/main/java/seedu/address/model/internship/StartDate.java
@@ -33,14 +33,17 @@ public class StartDate implements Comparable<StartDate> {
     }
 
     /**
-     * Verifies whether the given string constitutes a valid start date.
+     * Verifies whether the given string constitutes a valid start date. The given string is also stripped to
+     * defensively guard against instances where leading or trailing spaces are inserted when user directly modifies the
+     * internship.json file. This is important so that the given string does not fail the regex check.
      *
      * @param test The given string to be tested.
      * @return A boolean representing whether the string input is valid.
      */
     public static boolean isValidStartDate(String test) {
+        String strippedTest = test.strip();
         try {
-            LocalDate.parse(test, DATE_FORMATTER);
+            LocalDate.parse(strippedTest, DATE_FORMATTER);
             return true;
         } catch (DateTimeParseException e) {
             return false;

--- a/src/test/java/seedu/address/model/internship/ApplicationStatusTest.java
+++ b/src/test/java/seedu/address/model/internship/ApplicationStatusTest.java
@@ -21,8 +21,8 @@ class ApplicationStatusTest {
 
     @Test
     public void isValidApplicationStatus() {
-        // null applicationStatus -> returns false
-        assertFalse(ApplicationStatus.isValidApplicationStatus(null));
+        // null applicationStatus -> throws NullPointerException
+        assertThrows(NullPointerException.class, () -> ApplicationStatus.isValidApplicationStatus(null));
 
         // invalid applicationStatuses -> returns false
         assertFalse(ApplicationStatus.isValidApplicationStatus("")); // empty string


### PR DESCRIPTION
Currently, "Jane Street" and "Jane                            Street" are considered DISTINCT entries and it messes up the storage logic subsequently. 

This needs to change because intuitively users can accidently type an additional space or two (when they actually mean the same company name".

Modify the parsing logic to handle these 2 company names as identical.

Fixes #260 