### PR TITLE
Remove excess spaces from requirements

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -165,7 +165,7 @@ public class ParserUtil {
         requireNonNull(requirements);
         final Set<Requirement> requirementSet = new HashSet<>();
         for (String requirementName : requirements) {
-            requirementSet.add(parseRequirement(requirementName.strip()));
+            requirementSet.add(parseRequirement(requirementName.strip().replaceAll("\\s+", " ")));
         }
         return requirementSet;
     }


### PR DESCRIPTION
Currently, one can have excess internal white spaces in requirements.

This is bad as it affects filter's functionalities.

Remove excess internal white spaces

@yongning0310 Please check if this affects u are able to modify a command with excess internal white spaces in the requirements parameter. Flagship should trim all EXCESS internal white spaces